### PR TITLE
add linux-arm to build-matrix in deploy.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-13]
+        os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-13]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Should enable building aiocsv wheel to arm64 linux platform.