### PR TITLE
python 3.14 and free-threading

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,6 +22,7 @@ jobs:
         env:
           CIBW_ARCHS: auto
           CIBW_BUILD: cp3*-*
+          CIBW_ENABLE: cpython-freethreading
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.13t", "3.14", "3.14t"]
     steps:
     - uses: actions/checkout@v5
     - name: Set up Python ${{ matrix.python-version }}

--- a/aiocsv/_parser.c
+++ b/aiocsv/_parser.c
@@ -1,4 +1,4 @@
-// © Copyright 2020-2025 Mikołaj Kuranowski
+// © Copyright 2020-2026 Mikołaj Kuranowski
 // SPDX-License-Identifier: MIT
 
 #include <assert.h>
@@ -162,6 +162,9 @@ typedef struct {
     /// C-friendly representation of the csv dialect.
     Dialect dialect;
 
+    /// ID of the thread that has created the _Parser, to ensure it's not shared threads
+    unsigned long thread_id;
+
     /// Limit for the field size
     long field_size_limit;
 
@@ -294,6 +297,8 @@ static PyObject* Parser_new(PyTypeObject* subtype, PyObject* args, PyObject* kwa
     ModuleState* state = PyType_GetModuleState(subtype);
     Parser* self = PyObject_GC_New(Parser, subtype);
     if (!self) return NULL;
+
+    self->thread_id = PyThread_get_thread_ident();
 
     // Zero-initialize all custom Parser fields. In case the initialization fails,
     // we need to ensure the deallocator doesn't stumble on garbage values.
@@ -716,6 +721,12 @@ ret:
 }
 
 static PyObject* Parser_next(Parser* self) {
+    // Prevent _Parser from being shared across threads
+    if (self->thread_id != PyThread_get_thread_ident()) {
+        PyErr_SetString(PyExc_RuntimeError, "aiocsv._parser.Parser instance must not be shared across threads");
+        return NULL;
+    }
+
     // Loop until a record has been successfully parsed or EOF has been hit
     PyObject* record = NULL;
     while (!record && (self->buffer_str || !self->eof)) {

--- a/aiocsv/_parser.c
+++ b/aiocsv/_parser.c
@@ -690,6 +690,7 @@ static int Parser_finalize_read(Parser* self, PyObject* unicode) {
         PyErr_Format(PyExc_TypeError, "reader.read() returned %R, expected str", Py_TYPE(unicode));
         FINISH_WITH(0);
     }
+
 #if PY_VERSION_HEX < 0x030C0000
     // PyUnicode_READY is a guaranteed no-op starting with 3.12, but before that other
     // modules may produce strings using the deprecated path that requires preparation.
@@ -862,6 +863,9 @@ static PyModuleDef_Slot ModuleSlots[] = {
     {Py_mod_exec, module_exec},
 #if PY_VERSION_HEX >= 0x030C0000
     {Py_mod_multiple_interpreters, Py_MOD_PER_INTERPRETER_GIL_SUPPORTED},
+#endif
+#if PY_VERSION_HEX >= 0x030D0000
+    {Py_mod_gil, Py_MOD_GIL_NOT_USED},
 #endif
     {0, NULL},
 };


### PR DESCRIPTION
near as I can tell there is no shared state that requirers the GIL to lock around.  this PR:
- declares the gil is not needed
- removes deprecated PyUnicode_READY
- tests and builds on python 3.13t, 3.14, 3.14t

closes https://github.com/MKuranowski/aiocsv/issues/35